### PR TITLE
Issue #16 Fix space in path issue when invoking xjc

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.3.4
+version=1.3.5-SNAPSHOT
 bintray_username=djmijares
 bintray_api_key=""

--- a/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
@@ -59,7 +59,7 @@ class AntXjc implements AntExecutor {
       xsds.addToAntBuilder(ant, 'schema', FileCollection.AntType.FileSet)
       bindings.addToAntBuilder(ant, 'binding', FileCollection.AntType.FileSet)
       episodes.addToAntBuilder(ant, 'binding', FileCollection.AntType.FileSet)
-      arg(line : "-episode $episodeFile")
+      arg(line : "-episode '$episodeFile'")
       for (String val : extension.args) {
         arg(value: val)
       }


### PR DESCRIPTION
This is the quick fix for the path issue reported in #16

I can perfectly understand that more than just the change is required, but I admit having no idea where to start with tests for example.

I also included a version change, to replace 1.3.4 with 1.3.5-SNAPSHOT, let me know if this should be removed from the pull request.