### PR TITLE
Lots of little updates and a few features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,65 @@
-build
-*.class
+## java specific
+!.gitignore
+*.iml
+*.iws
+*.ipr
+*.lic
+target
+*/target
+*/*/target
+
+## vim objects
+*.swo
+*.swp
+
+## Build helper scripts
+*.bhs
+
+## Netbeans
+catalog.xml
+nbactions.xml
+
+## IntelliJ IDEA
+*.iml
+*.ipr
+*.iws
+.idea/
+local/
+
+# Gradle bits from: https://github.com/github/gitignore/blob/master/Gradle.gitignore
 .gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+## generic files to ignore
+*~
+*.lock
+*.DS_Store
+*.swp
+*.out
+jmeter.log
+
+## rcman
+rcman.conf
+rcman.log
+rsInstances
+nodeNames
+hosts.csv
+automation/rcman/files/*
+log.txt
+/test/JavaApplication1/nbproject/private/
+/test/artifact-behavior-test/responseBody
+/test/artifact-behavior-test/responseHeaders
+
+## Python
+*.py[cod]
+.Python
+
+## Eclipse
+# eclipse specific git ignore
+.project
+.metadata
+.classpath
+.settings

--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ These defaults are changed via the `jaxb` closure.
 * `bindings`
   * customization files to bind with
   * file name List of strings found in `bindingsDir`
-  * if there are bindings present, xjc will be called once with the
-    glob pattern `**/*.xsd` to snag everything under `xsdDir`.  Fixes
-    #27.
+  * The default glob pattern is `**/*.xjb`
 
 ## XJC Convention ##
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Several sensible defaults are defined to be passed into the
 
 | parameter				 | Description									    | default		  | type	  |
 | :---					 | :---:										    | :---:			  | ---:	  |
-|`destinationDir` _(R)_	 | generated code will be written to this directory | `${project.projectDir}/build/generated-sources/xjc` | `String`  |
+|`destinationDir` _(R)_	 | generated code will be written to this directory | `${project.buildDir}/generated-sources/xjc` | `String`  |
 |`extension` _(O)_		 | Run XJC compiler in extension mode			    | `true`		  | `boolean` |
 |`header` _(O)_			 | generates a header in each generated file	    | `true`		  | `boolean` |
-|`producesDir` _(O)(NI)_ | aids with XJC up-to-date check				    | `${project.projectDir}/build/generated-sources/xjc` | `String`  |
+|`producesDir` _(O)(NI)_ | aids with XJC up-to-date check				    | `${project.buildDir}/generated-sources/xjc` | `String`  |
 |`generatePackage` _(O)_ | specify a package to generate to				    | **none**		  | `String`  |
 |`args` _(O)_ | List of strings for extra arguments to pass that aren't listed | **none** | `List<String>` |
 |`removeOldOutput` _(O)_ | Only used with nested `<produces>` elements, when _'yes'_ all files are deleted before XJC is run | _'yes'_ | `String` |
@@ -185,7 +185,7 @@ substitute the version you are using.
 ### destinationDir ###
 
 `destinationDir` is relative to `project.rootDir`.  It is defaulted to
-`${project.projectDir}/build/generated-sources/xjc`, but can be set to anywhere.
+`${project.buildDir}/generated-sources/xjc`, but can be set to anywhere.
 
 ### producesDir ###
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ subproject { project ->
 
 applying the plugin to all schema projects.
 
+Another way to do this is by adding a boolean property to the
+`gradle.properties` file in the sub-projects. You can then use it this way:
+  
+```groovy
+subproject { project ->
+  if(Boolean.valueOf(project.getProperties().getOrDefault('doJAXB', 'false'))) { 
+    apply plugin: 'com.github.jacobono.jaxb'
+
+    dependencies { 
+      jaxb 'com.sun.xml.bind:jaxb-xjc:2.2.7-b41'
+      jaxb 'com.sun.xml.bind:jaxb-impl:2.2.7-b41'
+      jaxb 'javax.xml.bind:jaxb-api:2.2.7'
+    }
+  }
+}
+```
+
 Other Features
 ==============
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ These defaults are changed via the `jaxb` closure.
 * `xsdDir`
 	* Defined **by each** project to tell the plugin where to find the
       `.xsd` files to parse
+* `xsdIncludes`
+  * the schemas to compile
+  * file name List of strings found in `xsdDir`
+  * The default glob pattern is `**/*.xsd`
 * `episodesDir`
 	* i.e. _"build/generated-resources/episodes"_, _"episodes"_, _"schema/episodes"_, _"xsd/episodes"_,
       _"XMLSchema/episodes"_

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ new group id `com.github.jacobono` matches gradle plugin id.
 
 :boom: :collision:
 
-## Using Gradle 2.1 plugins script block
+## Using Gradle 2.10 plugins script block
 ```groovy
 plugins {
     id 'com.github.jacobono.jaxb' version '1.3.6'
@@ -137,17 +137,14 @@ There are 4 overrideable defaults for this JAXB Plugin.
 These defaults are changed via the `jaxb` closure.
 
 * `xsdDir`
-  * **ALWAYS** relative to `project.rootDir`
 	* Defined **by each** project to tell the plugin where to find the
       `.xsd` files to parse
 * `episodesDir`
-  * **ALWAYS** relative to `project.rootDir`
-	* i.e. _"episodes"_, _"schema/episodes"_, _"xsd/episodes"_,
+	* i.e. _"build/generated-resources/episodes"_, _"episodes"_, _"schema/episodes"_, _"xsd/episodes"_,
       _"XMLSchema/episodes"_
 	* **All** generated episode files go directly under here, no subfolders.
 * `bindingsDir`
-  * **ALWAYS** relative to `project.rootDir`
-	* i.e. "bindings", "schema/bindings", "xsd/bindings",
+	* i.e. "src/main/resources/schema", "bindings", "schema/bindings", "xsd/bindings",
       "XMLSchema/bindings"
     * User defined binding files to pass in to the `xjc` task
 	* **All** files are directly under this folder, _no subfolders_.
@@ -166,10 +163,10 @@ Several sensible defaults are defined to be passed into the
 
 | parameter				 | Description									    | default		  | type	  |
 | :---					 | :---:										    | :---:			  | ---:	  |
-|`destinationDir` _(R)_	 | generated code will be written to this directory | `src/main/java` | `String`  |
+|`destinationDir` _(R)_	 | generated code will be written to this directory | `${project.projectDir}/build/generated-sources/xjc` | `String`  |
 |`extension` _(O)_		 | Run XJC compiler in extension mode			    | `true`		  | `boolean` |
 |`header` _(O)_			 | generates a header in each generated file	    | `true`		  | `boolean` |
-|`producesDir` _(O)(NI)_ | aids with XJC up-to-date check				    | `src/main/java` | `String`  |
+|`producesDir` _(O)(NI)_ | aids with XJC up-to-date check				    | `${project.projectDir}/build/generated-sources/xjc` | `String`  |
 |`generatePackage` _(O)_ | specify a package to generate to				    | **none**		  | `String`  |
 |`args` _(O)_ | List of strings for extra arguments to pass that aren't listed | **none** | `List<String>` |
 |`removeOldOutput` _(O)_ | Only used with nested `<produces>` elements, when _'yes'_ all files are deleted before XJC is run | _'yes'_ | `String` |
@@ -185,9 +182,8 @@ substitute the version you are using.
 
 ### destinationDir ###
 
-`destinationDir` is relative to `project.projectDir`.  It is
-defaulted to `src/main/java`, but can be set to anywhere in
-`project.projectDir`.
+`destinationDir` is relative to `project.rootDir`.  It is defaulted to
+`${project.projectDir}/build/generated-sources/xjc`, but can be set to anywhere.
 
 ### producesDir ###
 
@@ -213,7 +209,7 @@ _(per project)_ is the `xsdDir`, and jaxb dependencies as described above.
 
 ```groovy
 jaxb {
-  xsdDir = "schema/folder1"
+  xsdDir = "${project.projectDir}/schema/folder1"
 }
 ```
 
@@ -231,7 +227,7 @@ dependencies {
 }
 
 jaxb {
-  xsdDir = "some/folder"
+  xsdDir = "${project.projectDir}/some/folder"
   xjc {
      taskClassname      = "org.jvnet.jaxb2_commons.xjc.XJC2Task"
 	 generatePackage    = "com.company.example"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ test {
 groovydoc {
   docTitle = "Gradle XSD Plugin"
   link("http://groovy.codehaus.org/gapi/", "groovy.", "org.codehaus.groovy.")
-  link("http://doc.oracle.com/javase/7/docs/api/", "java.")
+  link("http://docs.oracle.com/javase/8/docs/api/", "java.")
   link("http://google-guice.googlecode.com/svn/trunk/javadoc/", "com.google.")
   link("http://www.gradle.org/docs/current/javadoc/", "org.gradle.", "org.gradle.api.")
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,31 +2,31 @@ buildscript {
   //********************************************************************************
   // uncomment for local testing
   //--------------------------------------------------------------------------------
-  //repositories {
-  //  flatDir { dirs '../build/libs' }                          // gradle unversionedJar
-  //  //flatDir { dirs "/${gradle.gradleHomeDir}/lib/plugins" } // gradle installPlugin
-  //  jcenter()
-  //  mavenCentral()
-  //}
-  //
-  //dependencies {
-  //  classpath ':gradle-jaxb-plugin'
-  //  classpath 'com.google.inject:guice:3.0'
-  //  classpath 'com.github.jacobono:gradle-xsd-wsdl-slurping:1.1.2'
-  //}
-  //********************************************************************************
-
-  //********************************************************************************
-  // use artifacts from bintray
-  //--------------------------------------------------------------------------------
   repositories {
+    flatDir { dirs '../build/libs' }                          // gradle unversionedJar
+    //flatDir { dirs "/${gradle.gradleHomeDir}/lib/plugins" } // gradle installPlugin
     jcenter()
     mavenCentral()
   }
 
   dependencies {
-    classpath 'com.github.jacobono.plugins:gradle-jaxb-plugin:1.3.6'
+    classpath ':gradle-jaxb-plugin'
+    classpath 'com.google.inject:guice:3.0'
+    classpath 'com.github.jacobono:gradle-xsd-wsdl-slurping:1.1.2'
   }
+  //********************************************************************************
+
+  //********************************************************************************
+  // use artifacts from bintray
+  //--------------------------------------------------------------------------------
+  //repositories {
+  //  jcenter()
+  //  mavenCentral()
+  //}
+  //
+  //dependencies {
+  //  classpath 'com.github.jacobono:gradle-jaxb-plugin:1.3.6'
+  //}
   //********************************************************************************
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,21 +1,24 @@
 buildscript {
-  // uncomment for local testing  
-  //**********************************************************
-  // repositories {
-  //   flatDir { dirs '../build/libs' }
-  //   mavenCentral()
-  //   jcenter()
-  // }
+  //********************************************************************************
+  // uncomment for local testing
+  //--------------------------------------------------------------------------------
+  //repositories {
+  //  flatDir { dirs '../build/libs' }                          // gradle unversionedJar
+  //  //flatDir { dirs "/${gradle.gradleHomeDir}/lib/plugins" } // gradle installPlugin
+  //  jcenter()
+  //  mavenCentral()
+  //}
+  //
+  //dependencies {
+  //  classpath ':gradle-jaxb-plugin'
+  //  classpath 'com.google.inject:guice:3.0'
+  //  classpath 'com.github.jacobono:gradle-xsd-wsdl-slurping:1.1.2'
+  //}
+  //********************************************************************************
 
-  // dependencies {
-  //   classpath ':gradle-jaxb-plugin-1.3.6'
-  //   classpath 'com.google.inject:guice:3.0'
-  //   classpath 'com.github.jacobono:gradle-xsd-wsdl-slurping:1.1.2'
-  // }
-  //**********************************************************
-
+  //********************************************************************************
   // use artifacts from bintray
-  //******************************************************
+  //--------------------------------------------------------------------------------
   repositories {
     jcenter()
     mavenCentral()
@@ -24,23 +27,21 @@ buildscript {
   dependencies {
     classpath 'com.github.jacobono.plugins:gradle-jaxb-plugin:1.3.6'
   }
+  //********************************************************************************
 }
 
 allprojects { 
-
-  repositories { 
+  repositories {
     mavenCentral()
   }
-
 }
 
 subprojects { project ->
-
-  if(project.name.endsWith("-schema")) { 
+  if(project.name.endsWith("-schema")) {
     apply plugin: 'com.github.jacobono.jaxb'
-
-    dependencies { 
-      jaxb 'com.sun.xml.bind:jaxb-xjc:2.2.7-b41' //jaxws 2.2.6 uses jaxb 2.2.5, but can't dL 2.2.5 from maven the pom is off TODO
+    dependencies {
+      // TODO: jaxws 2.2.6 uses jaxb 2.2.5, but can't dL 2.2.5 from maven the pom is off
+      jaxb 'com.sun.xml.bind:jaxb-xjc:2.2.7-b41'
       jaxb 'com.sun.xml.bind:jaxb-impl:2.2.7-b41'
       jaxb 'javax.xml.bind:jaxb-api:2.2.7'
     }

--- a/examples/hello-world-bindings-schema/hello-world-bindings-schema.gradle
+++ b/examples/hello-world-bindings-schema/hello-world-bindings-schema.gradle
@@ -6,11 +6,12 @@ dependencies {
 }
 
 jaxb {
-  xsdDir = "schema/multiple"
-  bindingsDir = "schema/multiple/xjb"
+  xsdDir = "${project.rootDir}/schema/multiple"
+  bindingsDir = "${project.rootDir}/schema/multiple/xjb"
   bindings = ["xsd-bindings.xjb"]
   xjc {
     taskClassname = "org.jvnet.jaxb2_commons.xjc.XJC2Task"
     args = ["-Xannotate"]
+    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
   }
 }

--- a/examples/hello-world-bindings-schema/hello-world-bindings-schema.gradle
+++ b/examples/hello-world-bindings-schema/hello-world-bindings-schema.gradle
@@ -12,6 +12,6 @@ jaxb {
   xjc {
     taskClassname = "org.jvnet.jaxb2_commons.xjc.XJC2Task"
     args = ["-Xannotate"]
-    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+    destinationDir = "${project.buildDir}/generated-sources/xjc"
   }
 }

--- a/examples/hello-world-import-schema/hello-world-import-schema.gradle
+++ b/examples/hello-world-import-schema/hello-world-import-schema.gradle
@@ -1,5 +1,8 @@
 version = "0.1"
 
 jaxb { 
-  xsdDir = "schema/Import"
+  xsdDir = "${project.rootDir}/schema/Import"
+  xjc {
+    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+  }
 }

--- a/examples/hello-world-import-schema/hello-world-import-schema.gradle
+++ b/examples/hello-world-import-schema/hello-world-import-schema.gradle
@@ -3,6 +3,6 @@ version = "0.1"
 jaxb { 
   xsdDir = "${project.rootDir}/schema/Import"
   xjc {
-    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+    destinationDir = "${project.buildDir}/generated-sources/xjc"
   }
 }

--- a/examples/hello-world-schema/hello-world-schema.gradle
+++ b/examples/hello-world-schema/hello-world-schema.gradle
@@ -1,5 +1,8 @@
 version = "0.1"
 
 jaxb { 
-  xsdDir = "schema/HelloWorld"
+  xsdDir = "${project.rootDir}/schema/HelloWorld"
+  xjc {
+    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+  }
 }

--- a/examples/hello-world-schema/hello-world-schema.gradle
+++ b/examples/hello-world-schema/hello-world-schema.gradle
@@ -3,6 +3,6 @@ version = "0.1"
 jaxb { 
   xsdDir = "${project.rootDir}/schema/HelloWorld"
   xjc {
-    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+    destinationDir = "${project.buildDir}/generated-sources/xjc"
   }
 }

--- a/examples/hello-world-spaces-dir-schema/hello-world-spaces-dir-schema.gradle
+++ b/examples/hello-world-spaces-dir-schema/hello-world-spaces-dir-schema.gradle
@@ -2,8 +2,8 @@ version = "0.1"
 
 jaxb {
   xsdDir = "${project.rootDir}/schema/HelloWorld"
-  episodesDir = "${project.projectDir}/build/generated-resources/schema/space episodes"
+  episodesDir = "${project.buildDir}/generated-resources/schema/space episodes"
   xjc {
-    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+    destinationDir = "${project.buildDir}/generated-sources/xjc"
   }
 }

--- a/examples/hello-world-spaces-dir-schema/hello-world-spaces-dir-schema.gradle
+++ b/examples/hello-world-spaces-dir-schema/hello-world-spaces-dir-schema.gradle
@@ -1,6 +1,9 @@
 version = "0.1"
 
 jaxb {
-  xsdDir = "schema/HelloWorld"
-  episodesDir = "schema/space episodes"
+  xsdDir = "${project.rootDir}/schema/HelloWorld"
+  episodesDir = "${project.projectDir}/build/generated-resources/schema/space episodes"
+  xjc {
+    destinationDir = "${project.projectDir}/build/generated-sources/xjc"
+  }
 }

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -35,7 +35,7 @@ class JaxbPlugin implements Plugin<Project> {
 
   static final Logger log = Logging.getLogger(JaxbPlugin.class)
 
-  private JaxbExtension extension
+  private JaxbExtension jaxbExtension
 
   /**
    * Entry point for plugin.
@@ -47,8 +47,8 @@ class JaxbPlugin implements Plugin<Project> {
     Injector injector = Guice.createInjector([new JaxbPluginModule(), new DocSlurperModule()])
     configureJaxbExtension(project)
     configureJaxbConfiguration(project)
-    JaxbDependencyTree jnt = configureJaxbDependencyTree(project, extension, injector)
-    configureJaxbXjc(project, extension, jnt, injector)
+    JaxbDependencyTree jnt = configureJaxbDependencyTree(project, jaxbExtension, injector)
+    configureJaxbXjc(project, jaxbExtension, jnt, injector)
   }
   
   /**
@@ -59,8 +59,8 @@ class JaxbPlugin implements Plugin<Project> {
    * @see org.gradle.jacobo.plugins.extension.XjcExtension
    */
   private void configureJaxbExtension(final Project project) {
-    extension = project.extensions.create('jaxb', JaxbExtension, project)
-    extension.with {
+    jaxbExtension = project.extensions.create('jaxb', JaxbExtension, project)
+    jaxbExtension.with {
       xsdDir = "${project.projectDir}/src/main/resources/schema"
       xsdIncludes = ['**/*.xsd']
       episodesDir = "${project.projectDir}/build/generated-resources/episodes"

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -161,7 +161,7 @@ class JaxbPlugin implements Plugin<Project> {
    *
    * @param project  This plugins gradle project
    * @param jaxb  This plugins extension
-   * @param jnt  This plugins {@code xsd-dependency-tree} task (dependended upon)
+   * @param jnt  This plugins {@code xsd-dependency-tree} task (depended upon)
    * @param injector  This pluings Guice injector
    * @return  this plugins xjc tree task, configured
    * @see org.gradle.jacobo.plugins.task.JaxbXjc

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -75,6 +75,7 @@ class JaxbPlugin implements Plugin<Project> {
       extension = true
       removeOldOutput = 'yes'
       header = true
+      accessExternalSchema = 'file'
     }
   }
 

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -32,6 +32,7 @@ class JaxbPlugin implements Plugin<Project> {
   static final String JAXB_XSD_DEPENDENCY_TREE_TASK = 'xsd-dependency-tree'
   static final String JAXB_XJC_TASK = 'xjc'
   static final String JAXB_CONFIGURATION_NAME = 'jaxb'
+  static final String XJC_CONFIGURATION_NAME = 'xjc'
 
   static final Logger log = Logging.getLogger(JaxbPlugin.class)
 
@@ -48,6 +49,7 @@ class JaxbPlugin implements Plugin<Project> {
     configureJaxbExtension(project)
     configureJaxbConfiguration(project)
     JaxbDependencyTree jnt = configureJaxbDependencyTree(project, jaxbExtension, injector)
+    configureXjcConfiguration(project)
     configureJaxbXjc(project, jaxbExtension, jnt, injector)
   }
   
@@ -89,6 +91,19 @@ class JaxbPlugin implements Plugin<Project> {
       visible = true
       transitive = true
       description = "The JAXB XJC libraries to be used for this project."
+    }
+  }
+
+  /**
+   * Configures this plugins {@code xjc} configuration.
+   *
+   * @param project  This plugins gradle project
+   */
+  private void configureXjcConfiguration(final Project project) {
+    project.configurations.create(XJC_CONFIGURATION_NAME) {
+      visible = true
+      transitive = true
+      description = "The JAXB XJC plugin libraries to be used for this project."
     }
   }
 

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -63,15 +63,15 @@ class JaxbPlugin implements Plugin<Project> {
     jaxbExtension.with {
       xsdDir = "${project.projectDir}/src/main/resources/schema"
       xsdIncludes = ['**/*.xsd']
-      episodesDir = "${project.projectDir}/build/generated-resources/episodes"
+      episodesDir = "${project.buildDir}/generated-resources/episodes"
       bindingsDir = "${project.projectDir}/src/main/resources/schema"
       bindings = ['**/*.xjb']
     }
     def xjcExtension = project.jaxb.extensions.create('xjc', XjcExtension)
     xjcExtension.with {
       taskClassname = 'com.sun.tools.xjc.XJCTask'
-      destinationDir = "${project.projectDir}/build/generated-sources/xjc"
-      producesDir = "${project.projectDir}/build/generated-sources/xjc"
+      destinationDir = "${project.buildDir}/generated-sources/xjc"
+      producesDir = "${project.buildDir}/generated-sources/xjc"
       extension = true
       removeOldOutput = 'yes'
       header = true

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -71,7 +71,7 @@ class JaxbPlugin implements Plugin<Project> {
     }
     def xjcExtension = project.jaxb.extensions.create('xjc', XjcExtension)
     xjcExtension.with {
-      taskClassname = 'com.sun.tools.xjc.XJCTask'
+      taskClassname = 'com.sun.tools.xjc.XJC2Task'
       destinationDir = "${project.buildDir}/generated-sources/xjc"
       producesDir = "${project.buildDir}/generated-sources/xjc"
       extension = true

--- a/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/JaxbPlugin.groovy
@@ -62,9 +62,10 @@ class JaxbPlugin implements Plugin<Project> {
     extension = project.extensions.create('jaxb', JaxbExtension, project)
     extension.with {
       xsdDir = "${project.projectDir}/src/main/resources/schema"
+      xsdIncludes = ['**/*.xsd']
       episodesDir = "${project.projectDir}/build/generated-resources/episodes"
       bindingsDir = "${project.projectDir}/src/main/resources/schema"
-      bindings = []
+      bindings = ['**/*.xjb']
     }
     def xjcExtension = project.jaxb.extensions.create('xjc', XjcExtension)
     xjcExtension.with {
@@ -132,7 +133,7 @@ class JaxbPlugin implements Plugin<Project> {
     jnt.conventionMapping.xsds = {
       project.fileTree(
               dir: new File((String)project.jaxb.xsdDir),
-              include: '**/*.xsd'
+              include: project.jaxb.xsdIncludes
       )
     }
     jnt.conventionMapping.docFactory = {
@@ -197,7 +198,7 @@ class JaxbPlugin implements Plugin<Project> {
     xjc.conventionMapping.xsds = {
       project.fileTree(
               dir: new File((String)project.jaxb.xsdDir),
-              include: '**/*.xsd'
+              include: project.jaxb.xsdIncludes
       )
     }
     xjc.conventionMapping.schemasDirectory = { new File((String)project.jaxb.xsdDir) }

--- a/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
@@ -48,13 +48,18 @@ class AntXjc implements AntExecutor {
 		 classpath : classpath)
 
     def args = [destdir	        : extension.destinationDir,
-                extension	      : extension.extension,
+                extension	    : extension.extension,
                 removeOldOutput : extension.removeOldOutput,
                 header	        : extension.header]
     if (extension.generatePackage) {
       args << [package : extension.generatePackage]
     }
     log.info("xjc ant task is being passed these arguments: '{}'", args)
+    if(extension.accessExternalSchema == null) {
+      System.clearProperty('javax.xml.accessExternalSchema')
+    } else {
+      System.setProperty('javax.xml.accessExternalSchema', extension.accessExternalSchema)
+    }
     ant.xjc(args) {
       //TODO maybe should put the produces in there?
       //produces (dir : destinationDirectory)

--- a/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/ant/AntXjc.groovy
@@ -35,13 +35,14 @@ class AntXjc implements AntExecutor {
   public void execute(AntBuilder ant, Object... arguments) {
     XjcExtension extension = arguments[0]
     def classpath = arguments[1]
-    def xsds = arguments[2]
-    def bindings = arguments[3]
-    def episodes = arguments[4]
-    def episodeFile = arguments[5]
+    def pluginsPath = arguments[2]
+    def xsds = arguments[3]
+    def bindings = arguments[4]
+    def episodes = arguments[5]
+    def episodeFile = arguments[6]
 
-    log.info("xjc task is being passed these arguments: Plugin Extension '{}', classpath '{}', xsds '{}', bindings '{}', episodes '{}', episodeFile '{}'",
-             arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5])
+    log.info("xjc task is being passed these arguments: Plugin Extension '{}', classpath '{}', pluginsPath '{}', xsds '{}', bindings '{}', episodes '{}', episodeFile '{}'",
+            extension, classpath, pluginsPath, xsds, bindings, episodes, episodeFile)
 
     ant.taskdef (name : 'xjc',
 		 classname : extension.taskClassname,
@@ -67,6 +68,8 @@ class AntXjc implements AntExecutor {
       bindings.addToAntBuilder(ant, 'binding', FileCollection.AntType.FileSet)
       episodes.addToAntBuilder(ant, 'binding', FileCollection.AntType.FileSet)
       // ant's arg line is space delimited, won't work with spaces
+      arg(value : "-classpath")
+      arg(value : "$pluginsPath")
       arg(value : "-episode")
       arg(value : "$episodeFile")
       for (String val : extension.args) {

--- a/src/main/groovy/org/gradle/jacobo/plugins/extension/JaxbExtension.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/extension/JaxbExtension.groovy
@@ -19,6 +19,11 @@ class JaxbExtension {
   String xsdDir
 
   /**
+   * User defined list of RegEx strings to include from the {@code xsdDir}.
+   */
+  List xsdIncludes
+
+  /**
    * Folder name (under {@link org.gradle.api.Project#getRootDir()}) containing
    * user defined binding files to bind during the {@code xjc} task.
    */

--- a/src/main/groovy/org/gradle/jacobo/plugins/extension/XjcExtension.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/extension/XjcExtension.groovy
@@ -56,4 +56,9 @@ class XjcExtension {
    */
   List<String> args = []
 
+  /**
+   * The value to be used for the JVM System property {@code javax.xml.accessExternalSchema}
+   * See <a href="http://docs.oracle.com/javase/tutorial/jaxp/properties/properties.html">JAXP Properties</a>
+   */
+  String accessExternalSchema
 }

--- a/src/main/groovy/org/gradle/jacobo/plugins/extension/XjcExtension.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/extension/XjcExtension.groovy
@@ -13,8 +13,8 @@ class XjcExtension {
 
   /**
    * Destination directory for the generated output from the {@code xjc} task.
-   * Path is relative to this individual projects directory <b>NOT</b> the root
-   * directory.
+   * If the Path is not absolute, then it is assumed to be relative to this
+   * projects root directory.
    * See <a href="https://jaxb.java.net/2.2.4/docs/xjcTask.html">jaxb ant task</a>
    */
   String destinationDir

--- a/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
@@ -127,6 +127,7 @@ class JaxbXjc extends DefaultTask {
   def xjc(xsds, episodes, episodeFile) {
     def jaxbConfig = project.configurations[JaxbPlugin.JAXB_CONFIGURATION_NAME]
     log.debug("episodes are '{}' is empty '{}'", episodes, episodes.isEmpty())
+    new File((String)project.jaxb.xjc.destinationDir).mkdirs()
     getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, project.files(xsds),
                      getBindings(), project.files(episodes), episodeFile)
   }

--- a/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
@@ -126,9 +126,10 @@ class JaxbXjc extends DefaultTask {
 
   def xjc(xsds, episodes, episodeFile) {
     def jaxbConfig = project.configurations[JaxbPlugin.JAXB_CONFIGURATION_NAME]
+    def xjcConfig = project.configurations[JaxbPlugin.XJC_CONFIGURATION_NAME]
     log.debug("episodes are '{}' is empty '{}'", episodes, episodes.isEmpty())
     new File((String)project.jaxb.xjc.destinationDir).mkdirs()
-    getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, project.files(xsds),
+    getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, xjcConfig.asPath, project.files(xsds),
                      getBindings(), project.files(episodes), episodeFile)
   }
 

--- a/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
@@ -129,13 +129,8 @@ class JaxbXjc extends DefaultTask {
     def xjcConfig = project.configurations[JaxbPlugin.XJC_CONFIGURATION_NAME]
     log.debug("episodes are '{}' is empty '{}'", episodes, episodes.isEmpty())
     new File((String)project.jaxb.xjc.destinationDir).mkdirs()
-    log.info("   Locking XJC...")
-    synchronized (JaxbXjc.class) {
-      log.info("   Locked  XJC...")
-      getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, xjcConfig.asPath, project.files(xsds),
-                     getBindings(), project.files(episodes), episodeFile)
-      log.info("UN-Locked  XJC.")
-    }
+    getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, xjcConfig.asPath, project.files(xsds),
+                   getBindings(), project.files(episodes), episodeFile)
   }
 
   def getEpisodeFile(xsdNamespace) {

--- a/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
@@ -129,8 +129,13 @@ class JaxbXjc extends DefaultTask {
     def xjcConfig = project.configurations[JaxbPlugin.XJC_CONFIGURATION_NAME]
     log.debug("episodes are '{}' is empty '{}'", episodes, episodes.isEmpty())
     new File((String)project.jaxb.xjc.destinationDir).mkdirs()
-    getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, xjcConfig.asPath, project.files(xsds),
+    log.info("   Locking XJC...")
+    synchronized (JaxbXjc.class) {
+      log.info("   Locked  XJC...")
+      getXjc().execute(ant, project.jaxb.xjc, jaxbConfig.asPath, xjcConfig.asPath, project.files(xsds),
                      getBindings(), project.files(episodes), episodeFile)
+      log.info("UN-Locked  XJC.")
+    }
   }
 
   def getEpisodeFile(xsdNamespace) {

--- a/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
+++ b/src/main/groovy/org/gradle/jacobo/plugins/task/JaxbXjc.groovy
@@ -37,7 +37,7 @@ class JaxbXjc extends DefaultTask {
 
   /**
    * Directory where the generated java files from xjc would go
-   * Usually {@code <project-root>/src/main/java}
+   * Usually {@code <project-root>/build/generated-sources/xjc}
    */
   @OutputDirectory
   File generatedFilesDirectory

--- a/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
@@ -10,21 +10,21 @@ import org.gradle.jacobo.plugins.task.JaxbXjc
 
 class JaxbPluginSpec extends ProjectTaskSpecification {
 
-  def rootFolder = getFileFromResourcePath("/test-project")
+  def rootFolder = getFileFromResourcePath('/test-project')
   def setupSpec() {
-    def resourcesRoot = getFileFromResourcePath("/")
-    def rootFolder = new File(resourcesRoot, "test-project")
+    def resourcesRoot = getFileFromResourcePath('/')
+    def rootFolder = new File(resourcesRoot, 'test-project')
     rootFolder.mkdir()
   }
 
   def cleanupSpec() {
-    def rootFolder = getFileFromResourcePath("/test-project")
+    def rootFolder = getFileFromResourcePath('/test-project')
     rootFolder.delete()
   }
 
   def "applies Java plugin and adds extension object"() {
     expect:
-    project.plugins.getPlugin("java") instanceof JavaPlugin
+    project.plugins.getPlugin('java') instanceof JavaPlugin
     with(project.jaxb) {
       it instanceof JaxbExtension
       xsdDir == "${project.projectDir}/src/main/resources/schema"
@@ -38,11 +38,12 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
         extension == 'true'
         removeOldOutput == 'yes'
         header == true
+        accessExternalSchema == 'file'
       }
     }
   }
 
-  def "adds confiugration to this project"() {
+  def "adds configuration to this project"() {
     when:
     def jaxb = project.configurations.getByName(
       JaxbPlugin.JAXB_CONFIGURATION_NAME)
@@ -50,7 +51,7 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
     then:
     jaxb.visible == true
     jaxb.transitive == true
-    jaxb.description == "The JAXB XJC libraries to be used for this project."
+    jaxb.description == 'The JAXB XJC libraries to be used for this project.'
   }
 
   def "contains 2 tasks, xjc task depends on tree graph task"() {
@@ -59,7 +60,7 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
     def dependencyTask = project.tasks['xsd-dependency-tree']
 
     then:
-    [xjcTask, dependencyTask]*.group == ["parse", "parse"]
+    [xjcTask, dependencyTask]*.group == ['parse', 'parse']
     dependencyTask instanceof JaxbDependencyTree
     xjcTask instanceof JaxbXjc
     xjcTask.taskDependencies.getDependencies(xjcTask)*.path as Set ==
@@ -74,8 +75,8 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
       rootProject).build()
     def lastProject = ProjectBuilder.builder().withName('last').withParent(
       rootProject).build()
-    commonProject.apply(plugin: "com.github.jacobono.jaxb")
-    lastProject.apply(plugin: "com.github.jacobono.jaxb")
+    commonProject.apply(plugin: 'com.github.jacobono.jaxb')
+    lastProject.apply(plugin: 'com.github.jacobono.jaxb')
 
     lastProject.dependencies {
       compile commonProject

--- a/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
@@ -27,16 +27,16 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
     project.plugins.getPlugin("java") instanceof JavaPlugin
     with(project.jaxb) {
       it instanceof JaxbExtension
-      xsdDir == "schema"
-      episodesDir == "schema/episodes"
-      bindingsDir == "schema/bindings"
-      bindings == []
+      xsdDir == "${project.projectDir}/src/main/resources/schema"
+      episodesDir == "${project.projectDir}/build/generated-resources/episodes"
+      bindingsDir == "${project.projectDir}/src/main/resources/schema"
+      bindings == ['**/*.xjb']
       with(xjc) {
-      	destinationDir == "src/main/java"
-      	producesDir == "src/main/java"
-	extension == 'true'
-      	removeOldOutput == 'yes'
-	header == true
+        destinationDir == "${project.projectDir}/build/generated-sources/xjc"
+        producesDir == "${project.projectDir}/build/generated-sources/xjc"
+        extension == 'true'
+        removeOldOutput == 'yes'
+        header == true
       }
     }
   }

--- a/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
@@ -28,6 +28,7 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
     with(project.jaxb) {
       it instanceof JaxbExtension
       xsdDir == "${project.projectDir}/src/main/resources/schema"
+      xsdIncludes == ['**/*.xsd']
       episodesDir == "${project.projectDir}/build/generated-resources/episodes"
       bindingsDir == "${project.projectDir}/src/main/resources/schema"
       bindings == ['**/*.xjb']

--- a/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/JaxbPluginSpec.groovy
@@ -29,12 +29,12 @@ class JaxbPluginSpec extends ProjectTaskSpecification {
       it instanceof JaxbExtension
       xsdDir == "${project.projectDir}/src/main/resources/schema"
       xsdIncludes == ['**/*.xsd']
-      episodesDir == "${project.projectDir}/build/generated-resources/episodes"
+      episodesDir == "${project.buildDir}/generated-resources/episodes"
       bindingsDir == "${project.projectDir}/src/main/resources/schema"
       bindings == ['**/*.xjb']
       with(xjc) {
-        destinationDir == "${project.projectDir}/build/generated-sources/xjc"
-        producesDir == "${project.projectDir}/build/generated-sources/xjc"
+        destinationDir == "${project.buildDir}/generated-sources/xjc"
+        producesDir == "${project.buildDir}/generated-sources/xjc"
         extension == 'true'
         removeOldOutput == 'yes'
         header == true

--- a/src/test/groovy/org/gradle/jacobo/plugins/factory/XsdDependencyTreeFactorySpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/factory/XsdDependencyTreeFactorySpec.groovy
@@ -80,7 +80,7 @@ class XsdDependencyTreeFactorySpec extends NamespaceFixture {
     
     and: "get expecations for tree root and addChildren"
     def noDeps = getBaseNamespaces(baseNamespaces)
-    def expectations = addChildrenExpectations(addChildrenExpectations)
+    def expectations = addChildrenExpectations(addChildrenExpectationValues)
 
     and: "stub out manager getter calls"
     stubManagerGetCurrentRow(currentRows)
@@ -110,7 +110,7 @@ class XsdDependencyTreeFactorySpec extends NamespaceFixture {
       "RelatedAncestorDependencyScheme",
       "UnRelatedAncestorDependencyScheme"]
     baseNamespaces = ["xsd1", "xsd2"]
-    addChildrenExpectations << [
+    addChildrenExpectationValues << [
       [["xsd3":["xsd1"],"xsd4":["xsd2"]], ["xsd5":["xsd3"],"xsd6":["xsd4"]]],
       [["xsd3":["xsd1"], "xsd4":["xsd1", "xsd2"], "xsd5":["xsd2"]],
        ["xsd6":["xsd3"], "xsd7":["xsd3"], "xsd8":["xsd4", "xsd5"],

--- a/src/test/groovy/org/gradle/jacobo/plugins/resolver/EpisodeDependencyResolverSpec.groovy
+++ b/src/test/groovy/org/gradle/jacobo/plugins/resolver/EpisodeDependencyResolverSpec.groovy
@@ -12,7 +12,7 @@ class EpisodeDependencyResolverSpec extends TreeFixture {
   
   def resolver = new EpisodeDependencyResolver()
 
-  def episodesDir = new File("/schemas/episodes")
+  def episodesDir = new File('/build/generated-resources/episodes')
   def externalNamespaces = ["E1", "E2", "E3", "E4"]
   def converter = Mock(NamespaceToEpisodeConverter)
 


### PR DESCRIPTION
I would have normally split this into multiple PR's, but they were to interleaved and I wanted to get this back out.
- Changed the required relativity to the `project.dir` to instead use the standard Gradle naming.
- Added the ability to specify the specific XSD's that are actually compiled.
- Set a default bindings value to all: `**/*.xjb`
- Added support for setting the new `accessExternalSchema` system property in JSE 8.
- Added support for automatically creating the output directory as is standard in Gradle.
- Added support for setting the `classpath` argument of the XJC Ant task so that XJC plugins can be used.
- Added support for Gradle's new parallel project execution.

There are two unit tests that are failing using Gradle v1.12 and I can't get the integration tests to run at all.

I have also started trying to compile this under Gradle v2.10 and that is going fairly well. We forked it over here, https://github.com/rackerlabs/gradle-jaxb-plugin, and just brought in the source from the `gradle-xsd-wsdl-slurping` library. Same thing over there with not being able to run the integration tests~~, but there is only one test failing over there out of all the combined unit tests~~. It is also a different test than what is failing under Gradle v1.12. So I don't know.

Thanks for the great start on this, updating it was definitely better than starting from scratch.

EDIT: The last failing unit test was fixed with wdschei/gradle-jaxb-plugin@227e2d5a21110790eadcac507d8c8a82d90f4e79.
EDIT: There is also a simple parallel build test that uses the the Rackspace published artifacts here: https://github.com/wdschei/gradle-jaxb-plugin-test
