### PR TITLE
Specified groupId is incorrect. Should 'plugins' in the groupId be th…

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.github.jacobono.plugins:gradle-jaxb-plugin:1.3.6'
+    classpath 'com.github.jacobono:gradle-jaxb-plugin:1.3.6'
   }
 }
 


### PR DESCRIPTION
…ere.

It should not have plugins in the groupId.
dependencies {
    classpath 'com.github.jacobono.plugins:gradle-jaxb-plugin:1.3.6'
 }
